### PR TITLE
Updated Jath for most recent node.js

### DIFF
--- a/jath.js
+++ b/jath.js
@@ -115,7 +115,7 @@ function parseItem( template, xmldoc, node ) {
 		}
 	}
 	else if( m_browser == 'node' ) {
-		require('sys').puts( template );	
+		require('util').puts( template );	
 		return node.get( template ).text();
 	}
 	else {

--- a/jathnodetest.js
+++ b/jathnodetest.js
@@ -4,12 +4,14 @@ run test using node on the commandline:
 % node jathnodetest.js
 */
 
+var fs = require('fs');
 var xml = require('libxmljs');
-var sys = require('sys');
-var jath = require('jath');
+var util = require('util');
+var jath = require('./jath');
 var template = [ "//label", { id: "@id", added: "@added" } ];
-var testFile = xml.parseXmlFile('labels.xml');
 
-var result = jath.parse( template, testFile );
-
-sys.puts( sys.inspect( result, false, 10 ) );
+fs.readFile('labels.xml', 'ascii', function(err, data) {
+  var xmlDoc = xml.parseXmlString(data);
+  var result = jath.parse(template, xmlDoc);
+  util.puts(util.inspect(result, false, 10));
+});


### PR DESCRIPTION
Just pulled down the head of Jath and noticed that `node jathnodetest.js` didn't work using node-0.7.6-pre. Granted, I am working from the head of the node repo, but I believe the fixes I have made to get it to work here will be backwards compatible down to node 0.6, perhaps earlier (I'm a bit of a node novice so not sure how to check).

Basically, I have altered two main things to get the node test working:
- Swapped out the `sys` library for `util` in both `jathnodetest.js` and `jath.js`
- Removed the deprecated `parseXmlFile()` method from `libxmljs` and updated it using node's built in `fs` library.

Seems to work pretty well on my machine, gets rid of the errors, anyway!
